### PR TITLE
Fix local Docker startup for the Defects4C API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN mkdir /var/run/sshd && echo "export VISIBLE=now" >> /etc/profile
 #============================================================
 # Port exposing and ssh running
 #============================================================
-EXPOSE 22 6379
+EXPOSE 22 80 6379
 
 
 RUN    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /work/depot_tools.git && ln -s /work/depot_tools.git /work/depot_tools
@@ -166,12 +166,11 @@ RUN git clone -q --depth 1 -b release-1.12.1 https://github.com/google/googletes
     rm -rf /tmp/googletest && ldconfig
 
 # ── Python / uv ──
-RUN mkdir -p /src && \
-    if [ ! -d /src/.venv ]; then \
-      pip3 install -q uv && \
-      cd /src && uv venv --allow-existing; \
-    fi && \
-    . /src/.venv/bin/activate && \
+ENV DEFECTS4C_VENV=/opt/defects4c-venv
+RUN mkdir -p /src "$(dirname "${DEFECTS4C_VENV}")" && \
+    pip3 install -q uv && \
+    uv venv "${DEFECTS4C_VENV}" --allow-existing && \
+    . "${DEFECTS4C_VENV}/bin/activate" && \
     uv pip install \
       numpy cmake_format jinja2 pandas openai rich fastapi uvicorn jmespath \
       pytest pytest-asyncio pytest-tornasync pytest-trio pytest-twisted \
@@ -285,10 +284,14 @@ if [ "${KEYS}" -gt 0 ] && [ ! -f "${BACKUP}" ]; then
     echo "[entrypoint] Backup snapshot saved to ${BACKUP}"
 fi
 
-# ── 3. sshd (foreground — keeps the container alive) ─────────────────
-exec /usr/sbin/sshd -D
+# ── 3. sshd + API ────────────────────────────────────────────────────
+/usr/sbin/sshd
+echo "[entrypoint] sshd started"
+
+cd /src
+echo "[entrypoint] Starting web API"
+exec /usr/bin/env bash /src/run_web.sh
 EOF
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
-

--- a/defectsc_tpl/run_reproduce.sh
+++ b/defectsc_tpl/run_reproduce.sh
@@ -2,6 +2,25 @@
 project=$1
 project=$(basename $project)
 
+venv_candidates=()
+if [[ -n "${DEFECTS4C_VENV:-}" ]]; then
+        venv_candidates+=("${DEFECTS4C_VENV}")
+fi
+venv_candidates+=("/opt/defects4c-venv" "/src/.venv")
+
+python_bin=""
+for venv_dir in "${venv_candidates[@]}"; do
+        if [[ -x "${venv_dir}/bin/python" ]]; then
+                python_bin="${venv_dir}/bin/python"
+                break
+        fi
+done
+
+if [[ -z "${python_bin}" ]]; then
+        echo "No usable Python environment found. Set DEFECTS4C_VENV or create /opt/defects4c-venv." >&2
+        exit 1
+fi
+
 
 
 sha=$2
@@ -23,7 +42,7 @@ for one_sha in $sha_list ; do
         test_log="/out/$project/logs/${one_sha}.log"
 
         if [[ ! -f $test_log ]]; then 
-                /src/.venv/bin/python  bug_helper_v1_out2.py  reproduce   \
+                "${python_bin}" bug_helper_v1_out2.py reproduce \
                         "${project}@${one_sha}" 
         else 
                 echo "exist.....-->"$test_log
@@ -31,4 +50,3 @@ for one_sha in $sha_list ; do
         fi
 
 done 
-

--- a/defectsc_tpl/run_web.sh
+++ b/defectsc_tpl/run_web.sh
@@ -1,8 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+venv_candidates=()
+if [[ -n "${DEFECTS4C_VENV:-}" ]]; then
+    venv_candidates+=("${DEFECTS4C_VENV}")
+fi
+venv_candidates+=("/opt/defects4c-venv" "/src/.venv")
 
-source /src/.venv/bin/activate
+for venv_dir in "${venv_candidates[@]}"; do
+    if [[ -f "${venv_dir}/bin/activate" ]]; then
+        # shellcheck disable=SC1090
+        source "${venv_dir}/bin/activate"
+        break
+    fi
+done
+
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+    echo "No usable Python environment found. Set DEFECTS4C_VENV or create /opt/defects4c-venv." >&2
+    exit 1
+fi
+
 #exec /src/.venv/bin/python -m gunicorn defects4c_api:app \
 #     --worker-class uvicorn.workers.UvicornWorker \
 #     --bind 0.0.0.0:80


### PR DESCRIPTION
The local container startup path did not launch the HTTP API, so the documented port mapping to 11111 was live but no service was actually serving requests.

The runtime scripts also depended on /src/.venv, but /src is bind-mounted from the host in the documented docker run command. That mount hides the image-created virtualenv and causes run_web.sh and related scripts to fail.

This change:
- moves the image-managed virtualenv to /opt/defects4c-venv
- updates runtime scripts to use the stable venv location
- starts the web API from the container entrypoint after Redis is ready
- exposes port 80 in the image to match the documented host mapping

After this patch, the container serves the API on 127.0.0.1:11111 as expected and list_defects_bugid work without manual startup.